### PR TITLE
direct call to npm on remote

### DIFF
--- a/bin/nri.js
+++ b/bin/nri.js
@@ -70,7 +70,7 @@ function install(remote) {
 
     return new Promise((resolve, reject) => {
         const path = `${remote}/package`;
-        const cmd = ssh(`sudo -H npm --prefix ${path} install -g 2>&1`, sshopts);
+        const cmd = ssh(`sudo -H npm install -g --prefix ${path} 2>&1`, sshopts);
 
         cmd.pipe(process.stdout);
         cmd.on("error", reject);

--- a/bin/nri.js
+++ b/bin/nri.js
@@ -70,7 +70,7 @@ function install(remote) {
 
     return new Promise((resolve, reject) => {
         const path = `${remote}/package`;
-        const cmd = ssh(`cd ${path} && sudo -H npm install -g 2>&1`, sshopts);
+        const cmd = ssh(`sudo -H npm --prefix ${path} install -g 2>&1`, sshopts);
 
         cmd.pipe(process.stdout);
         cmd.on("error", reject);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nri",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "NPM remote install tool",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nri",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "NPM remote install tool",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Previous deployment failed with simply `Non-zero exit code`.  This should ensure any errors encountered here are caught by `npm` and are more verbose.