### PR TITLE
use npm pack for local install

### DIFF
--- a/bin/nri.js
+++ b/bin/nri.js
@@ -47,7 +47,7 @@ function copyPackage(local, remote) {
 function install(remote) {
     console.info(`running installer from ${remote} on ${host}`);
     return ssh(`cd ${remote}/package && npm install 2>&1`)
-        .then(() => ssh(`cd ${remote}/package && sudo -H npm install -g 2>&1`))
+        .then(() => ssh(`cd ${remote}/package && sudo -H npm install -g $(npm pack) 2>&1`))
         .then(() => remote);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nri",
-  "version": "0.9.10",
+  "version": "0.10.0",
   "description": "NPM remote install tool",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Newer versions of NPM won't do an install from a local directory; this change uses `npm pack` as a workaround by bundling the directory into a zip file and passing that to npm.